### PR TITLE
Support OVN in offline-dbg

### DIFF
--- a/bin/offline-dbg
+++ b/bin/offline-dbg
@@ -135,6 +135,12 @@ EOF
     kubectl exec -i -n $OVN_NAMESPACE $ovnkube_node ovsdb-client backup > ${WORKDIR}/${ovnkube_node}_ovs.db
     do_collect-db ${WORKDIR}/${ovnkube_node}_ovs.db ovs
 
+    # Collect OVN information
+    ovnkube_db_pod=$(kubectl get pods -n $OVN_NAMESPACE -o name | grep ovnkube-db | sed "s/^.\{4\}//")
+    kubectl cp -n ${OVN_NAMESPACE} ${ovnkube_db_pod}:/etc/openvswitch/ovnnb_db.db  ${WORKDIR}/ovnnb_db.db
+    kubectl cp -n ${OVN_NAMESPACE} ${ovnkube_db_pod}:/etc/openvswitch/ovnsb_db.db  ${WORKDIR}/ovnsb_db.db
+    do_collect-db ${WORKDIR}/ovnnb_db.db ovn_nb
+    do_collect-db ${WORKDIR}/ovnsb_db.db ovn_sb
 }
 
 check_for_OpenFlow_14() {

--- a/bin/offline-dbg
+++ b/bin/offline-dbg
@@ -77,7 +77,7 @@ do_collect-db() {
     local dest_dbfile=${WORKDIR}/db/${name}/$(basename -- ${orig_dbfile})
 
     if [ -f ${dest_dbfile} ]; then
-        error "${dest_dbfile} already exists"
+        error "A database of type ${name} already exists in the current working directory. Run 'stop' or select a different working directory"
     fi
 
     mkdir -p ${WORKDIR}/db/${name}
@@ -152,7 +152,30 @@ check_for_OpenFlow_14() {
     else
         [ ${version#OpenFlow} -ge 14 ] && bundle=" --bundle" || bundle=""
         echo $bundle
-    fi                    
+    fi
+}
+
+do_collect-sos-ovn() {
+    if [ $# -lt 1 ]; then
+        usage
+        exit 1
+    fi
+    local sos=$1
+    local dir_name=`tar -tf $sos | head -1 | cut -f1 -d"/"`
+    local ovn_nb_file="${dir_name}/var/lib/openvswitch/ovn/ovnnb_db.db"
+    local ovn_sb_file="${dir_name}/var/lib/openvswitch/ovn/ovnsb_db.db"
+
+    [ -f "$sos" ] ||  error "SOS archive file not found. Please specify a <sosreport>.tar.xz archive"
+
+    mkdir -p ${WORKDIR}/sos_report
+
+    echo "Extracting OVN data from sos report..."
+    tar -xvf $sos -C ${WORKDIR}/sos_report $ovn_nb_file --strip-components=5 &>/dev/null || error "Could not extract OVN NB database"
+    tar -xvf $sos -C ${WORKDIR}/sos_report $ovn_sb_file --strip-components=5 &>/dev/null || error "Could not extract OVN NB database"
+    do_collect-db "${WORKDIR}/sos_report/ovnnb_db.db" "ovn_nb"
+    rm "${WORKDIR}/sos_report/ovnnb_db.db"
+    do_collect-db "${WORKDIR}/sos_report/ovnsb_db.db" "ovn_sb"
+    rm "${WORKDIR}/sos_report/ovnsb_db.db"
 }
 
 do_collect-sos-ovs() {
@@ -166,10 +189,10 @@ do_collect-sos-ovs() {
     local db_locations="var/lib/openvswitch etc/openvswitch usr/local/etc/openvswitch"
 
     if test -f "$sos"; then
-        mkdir ${WORKDIR}/sos_report || error "Sos_report already exists. To collect a new sos report, first run 'stop' or set a new \${WORKDIR}"
+        mkdir -p ${WORKDIR}/sos_report
         echo "Extracting sos report from '$sos'..."
     else
-        echo "SOS archive file not found. Please specify a <sosreport>.tar.xz archive"
+        error "SOS archive file not found. Please specify a <sosreport>.tar.xz archive"
     fi
 
     for dir in $sos_files; do
@@ -215,7 +238,7 @@ do_collect-sos-ovs() {
     else
         error "ovs-vsctl_-t_5_list-br missing from sos report. Make sure your sos archive is generated from the most recent sos report"
     fi
-    
+
     # Collect group, flow, and tlv dumps
     for br in $bridges; do
         local version=$(ls $CMD_DIR | grep ovs-ofctl_-O_OpenFlow[0-9]*_dump-flows_${br} | grep -o "OpenFlow[0-9]*")
@@ -330,7 +353,7 @@ print_tools() {
         if ls -x ${VAR_RUN}/${type}/*.sock &>/dev/null; then
             db_sock=$(ls -x $VAR_RUN/${type}/*.sock)
             command=""
-            case ${type} in 
+            case ${type} in
                 ovs)
                     command="ovs-vsctl"
                     ;;
@@ -402,6 +425,13 @@ case $CMD in
         echo ""
         echo ""
         echo "Offline OVS Debugging: OVS data collected and stored in ${WORKDIR}"
+        echo "*******************************************************************"
+        ;;
+    collect-sos-ovn)
+        do_collect-sos-ovn $@
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: OVN data collected and stored in ${WORKDIR}"
         echo "*******************************************************************"
         ;;
     collect-db-ovs)

--- a/bin/offline-dbg
+++ b/bin/offline-dbg
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -eu
 
 SCRIPT=`realpath -s $0`
@@ -30,11 +29,13 @@ usage() {
     echo "    Options":
     echo "       -o:    Openshift environment"
     echo ""
-    echo "  collect-sos SOS      Collects information from the provided sos.tar.xz and saves it in the working directory"
-    echo "  collect-db  DBFILE   Collects the provided database file and prepares it for offline debugging"
+    echo "  collect-sos-ovs      SOS      Collects the OpenvSwitch information from the provided sos.tar.xz and prepares it for offline debugging"
     echo ""
-    echo "  start [SERVICE]      Starts an offline debugging session service. hData must have been previously collected in the working directory"
-    echo "                       Supported services: ovsdb, vswitchd, all(default)"
+    echo "  collect-db-ovs       DBFILE   Collects the provided OpenvSwitch database file and prepares it for offline debugging"
+    echo "  collect-db-ovn-nb    DBFILE   Collects the provided OVN_Northbound database file and prepares it for offline debugging"
+    echo "  collect-db-ovn-sb    DBFILE   Collects the provided OVN_Southbound database file and prepares it for offline debugging"
+    echo ""
+    echo "  start                Starts an offline debugging session service. Data must have been previously collected in the working directory"
     echo ""
     echo "  stop                 Stops the offline debugging environment"
     echo ""
@@ -52,38 +53,35 @@ error() {
 }
 
 do_build() {
-    echo "Offline OVS Debugging: building images"
-    echo "***************************************"
-
     docker build -t ovs-dbg -f ${CONTAINER_PATH}/Dockerfile ${CONTAINER_PATH}
 }
 
 do_stop() {
-    docker kill ovsdb-server &>/dev/null || true
     docker kill ovs-vswitchd &>/dev/null || true
-    docker rm ovsdb-server &>/dev/null || true
     docker rm ovs-vswitchd &>/dev/null || true
+    docker kill ovsdb-server-ovs &>/dev/null || true
+    docker rm ovsdb-server-ovs &>/dev/null || true
+    docker kill ovsdb-server-ovn_nb &>/dev/null || true
+    docker rm ovsdb-server-ovn_nb &>/dev/null || true
+    docker kill ovsdb-server-ovn_sb &>/dev/null || true
+    docker rm ovsdb-server-ovn_sb &>/dev/null || true
     rm -rf ${WORKDIR}
-    echo "Offline OVS Debugging stopped"
-    echo "*****************************"
-}
-
-process_dbfile() {
-    local orig_dbfile=$1
-    local final_dbfile=$WORKDIR/final.db
-    if [ -f ${final_dbfile} ]; then
-        echo "Warning, overwriting DB file $final_dbfile"
-    fi
-    ovs
 }
 
 do_collect-db() {
+    # $1: database file to backup
+    # $2: name of the database (ovs | ovn_nb | ovn_sb)
     local orig_dbfile=$1
-    cp $orig_dbfile $WORKDIR/db.conf
-    echo ""
-    echo ""
-    echo "Offline OVS Debugging: DB file collected and stored in ${WORKDIR}"
-    echo "*****************************************************************"
+    local name=$2
+
+    local dest_dbfile=${WORKDIR}/db/${name}/$(basename -- ${orig_dbfile})
+
+    if [ -f ${dest_dbfile} ]; then
+        error "${dest_dbfile} already exists"
+    fi
+
+    mkdir -p ${WORKDIR}/db/${name}
+    cp $orig_dbfile ${dest_dbfile}
 }
 
 do_collect-k8s() {
@@ -134,12 +132,9 @@ EOF
 
     # Collect the DB backup
     mkdir -p $VAR_RUN
-    kubectl exec -i -n $OVN_NAMESPACE $ovnkube_node ovsdb-client backup > ${WORKDIR}/db.conf
+    kubectl exec -i -n $OVN_NAMESPACE $ovnkube_node ovsdb-client backup > ${WORKDIR}/${ovnkube_node}_ovs.db
+    do_collect-db ${WORKDIR}/${ovnkube_node}_ovs.db ovs
 
-    echo ""
-    echo ""
-    echo "Offline OVS Debugging: data collected and stored in ${WORKDIR}"
-    echo "**************************************************************"
 }
 
 check_for_OpenFlow_14() {
@@ -154,17 +149,14 @@ check_for_OpenFlow_14() {
     fi                    
 }
 
-do_collect-sos() {
+do_collect-sos-ovs() {
     if [ $# -lt 1 ]; then
         usage
         exit 1
     fi
     local sos=$1
-
     local dir_name=`tar -tf $sos | head -1 | cut -f1 -d"/"`
-
     local sos_files="${dir_name}/sos_commands/rpm ${dir_name}/sos_commands/openvswitch"
-
     local db_locations="var/lib/openvswitch etc/openvswitch usr/local/etc/openvswitch"
 
     if test -f "$sos"; then
@@ -193,7 +185,8 @@ do_collect-sos() {
         echo "If the target cluster has defined \$ovs_dbdir it could be located there"
         echo "Please add manually using collect-db and re-run collect-sos"
     else
-        mv ${WORKDIR}/sos_report/${db_dir}/conf.db ${WORKDIR}/db.conf
+        do_collect-db ${WORKDIR}/sos_report/${db_dir}/conf.db ovs
+        rm ${WORKDIR}/sos_report/${db_dir}/conf.db
     fi
 
     # OVS 2.7 and earlier do not enable OpenFlow 1.4 (by default) and lack
@@ -263,91 +256,103 @@ do_collect-sos() {
     done
 
     mkdir -p $VAR_RUN
-
-    echo ""
-    echo ""
-    echo "Offline OVS Debugging: data collected and stored in ${WORKDIR}"
-    echo "**************************************************************"
 }
 
 start_ovsdb() {
     # run ovsdb-server
-    docker kill ovsdb-server &>/dev/null || true
-    docker rm ovsdb-server &>/dev/null || true
-    docker run -d -p 127.0.0.1:6640:6640/tcp -v ${WORKDIR}/db.conf:/usr/local/var/run/openvswitch/db.backup -v ${VAR_RUN}:/usr/local/var/run/openvswitch/  --name ovsdb-server ovs-dbg ovsdb
+    # $1 : database_type (directory within $WORKDIR/db)
+    local name=$1
+    local db_file=$(ls -x ${WORKDIR}/db/${name} | tail -1)
+    local backup_local_file=${WORKDIR}/db/${name}/${db_file}
+
+    local remote_var_run=/usr/local/var/run/openvswitch
+    local local_var_run=${VAR_RUN}/${name}
+
+    local container_name=ovsdb-server-${name}
+    local backup_file=${remote_var_run}/${name}.db
+    local socket_file=${remote_var_run}/${name}.sock
+
+    docker kill ovsdb-server-${name} &>/dev/null || true
+    docker rm ovsdb-server-${name} &>/dev/null || true
+
+    echo "Starting container ovsdb-server-${name}"
+    docker run -d -e OVSDB_BACKUP=${backup_file} -e OVSDB_SOCKET=${socket_file} -v ${backup_local_file}:${backup_file} -v ${local_var_run}:${remote_var_run} --name ovsdb-server-${name} ovs-dbg ovsdb
     sleep 3
 }
 
 start_vswitchd() {
     # run ovs-vswitchd
+    local remote_var_run=/usr/local/var/run/openvswitch
+    local socket_file=${remote_var_run}/ovs.sock
+    local local_var_run=${VAR_RUN}/ovs
+
     docker kill ovs-vswitchd &>/dev/null || true
     docker rm ovs-vswitchd &>/dev/null || true
-    docker run -d -p 127.0.0.1:16640:6640/tcp -e RESTORE_DIR="/root/restore_flows" -v ${WORKDIR}/restore_flows:"/root/restore_flows" -v ${VAR_RUN}:/usr/local/var/run/openvswitch/ --name ovs-vswitchd --rm ovs-dbg vswitchd-dummy
+
+    echo "Starting container ovs-vswitchd"
+    docker run -d -e OVSDB_SOCKET=${socket_file} -e RESTORE_DIR="/root/restore_flows" -v ${WORKDIR}/restore_flows:"/root/restore_flows" -v ${local_var_run}:${remote_var_run} --name ovs-vswitchd --rm ovs-dbg vswitchd-dummy
     sleep 3
 }
 
 do_start() {
-    local svc=${1-all}
-
     # Ensure ovs-dbg image is present
     docker inspect ovs-dbg 2>&1 >/dev/null || (
         echo "Failed to find a local container named ovs-dbg. Pulling from quay.io/amorenoz/ovs-dbg"
         docker pull quay.io/amorenoz/ovs-dbg && docker tag quay.io/amorenoz/ovs-dbg ovs-dbg
     )
 
-    case ${svc} in
-        all)
-            start_ovsdb
+    for db_type in $(ls -x ${WORKDIR}/db); do
+        start_ovsdb ${db_type}
+        if [ ${db_type} == "ovs" ]; then
             start_vswitchd
-            ;;
-        ovsdb)
-            start_ovsdb
-            ;;
-        vswitchd)
-            start_vswitchd
-            ;;
-        *)
-            usage
-            exit 1
-    esac
-
-    echo ""
-    echo "Offline OVS Debugging started"
-    echo "******************************"
-    echo ""
-    print_tools
-
+        fi
+    done
 }
 
 print_tools() {
     echo "Working directory: $WORKDIR:"
 
-    if ls -x $VAR_RUN/ovs-vswitchd.*.ctl &>/dev/null; then
-        vswitchd_ctl=$(ls -x $VAR_RUN/ovs-vswitchd.*.ctl)
+    if ls -x $VAR_RUN/ovs/ovs-vswitchd.*.ctl &>/dev/null; then
+        vswitchd_ctl=$(ls -x $VAR_RUN/ovs/ovs-vswitchd.*.ctl)
         echo ""
-        echo "openvswitch control found at ${vswitchd_ctl}"
-        echo "You can run ovs-appctl commands as:"
-        echo "   ovs-appctl --target=${vswitchd_ctl} [...]"
+        echo "* openvswitch control found at ${vswitchd_ctl}"
+        echo "  You can run ovs-appctl commands as:"
+        echo "      ovs-appctl --target=${vswitchd_ctl} [...]"
     fi
 
-    if ls -x $VAR_RUN/db.sock &>/dev/null; then
-        ovsdb_sock=$(ls -x $VAR_RUN/db.sock)
-        echo ""
-        echo "OVSDB socket found at ${ovsdb_sock}"
-        echo "You can run ovsdb commands such as:"
-        echo "   ovs-vsctl --db unix:${ovsdb_sock} [...]"
-        echo "   ovn-nbctl --db unix:${ovsdb_sock} [...]"
-        echo "   ovn-sbctl --db unix:${ovsdb_sock} [...]"
-        echo "   ovsdb-client ${ovsdb_sock} [...]"
-    fi
+    for type in ovs ovn_nb ovn_sb; do
+        if ls -x ${VAR_RUN}/${type}/*.sock &>/dev/null; then
+            db_sock=$(ls -x $VAR_RUN/${type}/*.sock)
+            command=""
+            case ${type} in 
+                ovs)
+                    command="ovs-vsctl"
+                    ;;
+                ovn_nb)
+                    command="ovn-nbctl"
+                    ;;
+                ovn_sb)
+                    command="ovn-sbctl"
+                    ;;
+                *)
+                    error "Unkown db socket file ${db_sock}"
+            esac
+            echo ""
+            echo "* ${type} ovsdb-server socket found at ${db_sock}"
+            echo "  You can run commands such as:"
+            echo "      ${command} --db unix:${db_sock} [...]"
+            echo "  or"
+            echo "      ovsdb-client ${db_sock} [...]"
+        fi
+    done
 
-    if ls -x $VAR_RUN/*.mgmt &>/dev/null; then
-        ofproto_socks=$(ls -x $VAR_RUN/*.mgmt)
+    if ls -x $VAR_RUN/ovs/*.mgmt &>/dev/null; then
+        ofproto_socks=$(ls -x $VAR_RUN/ovs/*.mgmt)
         echo ""
-        echo "openflow bridge management sockets found at ${ofproto_socks}"
-        echo "You can run ofproto commands such as:"
-        for mgt in $(ls -x $VAR_RUN/*.mgmt); do
-            echo "   ovs-ofctl [...] ${mgt}"
+        echo "* openflow bridge management sockets found at ${ofproto_socks}"
+        echo "  You can run ofproto commands such as:"
+        for mgt in $(ls -x $VAR_RUN/ovs/*.mgmt); do
+            echo "      ovs-ofctl [...] ${mgt}"
         done
     fi
 }
@@ -381,24 +386,59 @@ mkdir -p ${WORKDIR}
 case $CMD in
     collect-k8s)
         do_collect-k8s $@
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: data collected and stored in ${WORKDIR}"
+        echo "**********************"
         ;;
-    collect-sos)
-        do_collect-sos $@
+    collect-sos-ovs)
+        do_collect-sos-ovs $@
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: OVS data collected and stored in ${WORKDIR}"
+        echo "*******************************************************************"
         ;;
-    collect-db)
-        do_collect-db $@
+    collect-db-ovs)
+        do_collect-db $@ "ovs"
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: OVS DB file collected and stored in ${WORKDIR}"
+        echo "**********************"
+        ;;
+    collect-db-ovn-nb)
+        do_collect-db $@ "ovn_nb"
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: OVN NB DB file collected and stored in ${WORKDIR}"
+        echo "**********************"
+        ;;
+    collect-db-ovn-sb)
+        do_collect-db $@ "ovn_sb"
+        echo ""
+        echo ""
+        echo "Offline OVS Debugging: OVN SB DB file collected and stored in ${WORKDIR}"
+        echo "**********************"
         ;;
     build)
         do_build $@
+        echo "Offline OVS Debugging: images built"
+        echo "***********************************"
         ;;
     start)
         do_start $@
+        echo ""
+        echo "Offline OVS Debugging started"
+        echo "******************************"
+        echo ""
+        print_tools
         ;;
     print)
         print_tools
         ;;
     stop)
         do_stop $@
+        echo "Offline OVS Debugging stopped"
+        echo "*****************************"
         ;;
     *)
         echo "Invalid command $CMD" 1>&2

--- a/docs/source/ofofproto.rst
+++ b/docs/source/ofofproto.rst
@@ -1,20 +1,24 @@
 ======================
-(PoC) offline-dbg
+offline-dbg
 ======================
 
-The offline-dbg tool helps you debug OVS issues offline by recreating the OVSDB
-and the Openflow flows from a remote Kubernetes / Openshift node running ovn-kubernetes
+The **offline-dbg** tool helps you debug OVS issues offline by recreating the OVSDB and the Openflow flows.
 
 ------
 Usage
 ------
 
+In general, the tool work in two steps. First you must **collect** the logs, flows etc, and then you **start** the offline debugging environment
+
 (Optional) Build the ovs-dbg container:
 
 ::
 
-    cd containers/ovs-dbg && docker build --build-arg OVS_VERSION=<TAG/HASH/BRANCH> -t ovs-dbg .
+    ./bin/offline-dbg build
 
+
+Collect data from a running kubernetes / Openshift cluster
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Make sure you can access the remote k8s/oc node:
 
@@ -23,14 +27,62 @@ Make sure you can access the remote k8s/oc node:
     kubectl get nodes
 
 
-Start the offline debugging setup by selecting the NODE you want to debug:
+Select the NODE you want to "recreate" and run:
 
 ::
 
-    ./bin/offline-dbg start ovn-worker
+    ./bin/offline-dbg collect-k8s ovn-worker
 
 
-To clean the setup run:
+
+Collect data from a Database backup file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    ./bin/offline-dbg collect-db-ovs /path/to/openvswitch/conf.db
+
+
+You can also collect OVN NB and OVN SB databases:
+
+::
+
+    ./bin/offline-dbg collect-db-ovn-nb /path/to/ovnnb_db.db
+
+
+::
+
+    ./bin/offline-dbg collect-db-ovn-nb /path/to/ovnsb_db.db
+
+
+Collect data from a sos report archive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Note collecting OVS information from sos archives requires a recent sos package.
+
+::
+
+    ./bin/offline-dbg collect-sos-ovs /path/to/sos_compute.tar.xz
+
+::
+
+    ./bin/offline-dbg collect-sos-ovn /path/to/sos_controller.tar.xz
+
+
+
+Start the setup
+^^^^^^^^^^^^^^^
+
+::
+
+    ./bin/offline-dbg start
+
+
+Once you start, the tool will print the commands that are available for offline debugging.
+
+
+Stop and clean the setup
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 


### PR DESCRIPTION
Currently there are an issue preventing us from really doing OVN troubleshooting with this tool:
We can't run multiple ovsdb-server instances at the same time

This PR adds support for multiple ovsdb-servers, adds collect-db-ovn-{nb,sb} to the commandline and prints OVN hint commands nicely.

Also, it collects the OVN database from a running k8s cluster. As a result, after collecting k8s data:

```
$ ./bin/offline-dbg collect-k8s ovn_worker && ./bin/offline-dbg start
[...]
Offline OVS Debugging started                                                                                                            
******************************                                                                                                           
                                                                                                                                         
Working directory: /tmp/ovs-offline-dbg:                                                                                                 
                                                                                                                                         
* openvswitch control found at /tmp/ovs-offline-dbg/var-run/ovs/ovs-vswitchd.8.ctl                                                       
  You can run ovs-appctl commands as:                                                                                                    
      ovs-appctl --target=/tmp/ovs-offline-dbg/var-run/ovs/ovs-vswitchd.8.ctl [...]                                                      
                                                                                                                                         
* ovs ovsdb-server socket found at /tmp/ovs-offline-dbg/var-run/ovs/ovs.sock                                                             
  You can run commands such as:                                                                                                          
      ovs-vsctl --db unix:/tmp/ovs-offline-dbg/var-run/ovs/ovs.sock [...]                                                                
  or                                                                                                                                     
      ovsdb-client /tmp/ovs-offline-dbg/var-run/ovs/ovs.sock [...]                                                                       
                                                                                                                                         
* ovn_nb ovsdb-server socket found at /tmp/ovs-offline-dbg/var-run/ovn_nb/ovn_nb.sock                                                    
  You can run commands such as:                                                                                                          
      ovn-nbctl --db unix:/tmp/ovs-offline-dbg/var-run/ovn_nb/ovn_nb.sock [...]                                                          
  or                                                                                                                                     
      ovsdb-client /tmp/ovs-offline-dbg/var-run/ovn_nb/ovn_nb.sock [...]                                                                 
                                                                                                                                         
* ovn_sb ovsdb-server socket found at /tmp/ovs-offline-dbg/var-run/ovn_sb/ovn_sb.sock                                                    
  You can run commands such as:                                                                                                          
      ovn-sbctl --db unix:/tmp/ovs-offline-dbg/var-run/ovn_sb/ovn_sb.sock [...]                                                          
  or                                                                                                                                     
      ovsdb-client /tmp/ovs-offline-dbg/var-run/ovn_sb/ovn_sb.sock [...]                                                                 
                                                                                                                                         
* openflow bridge management sockets found at /tmp/ovs-offline-dbg/var-run/ovs/breth0.mgmt                                               
/tmp/ovs-offline-dbg/var-run/ovs/br-int.mgmt                                                                                             
  You can run ofproto commands such as:                                                                                                  
      ovs-ofctl [...] /tmp/ovs-offline-dbg/var-run/ovs/breth0.mgmt                                                                       
      ovs-ofctl [...] /tmp/ovs-offline-dbg/var-run/ovs/br-int.mgmt                                                                       
```

You can even run ovn-detrace as:

```
 $ ovn-detrace --ovnsb=unix:/tmp/ovs-offline-dbg/var-run/ovn_sb/ovn_sb.sock --ovnnb=unix:/tmp/ovs-offline-dbg/var-run/ovn_nb/ovn_nb.sock --ovsdb=unix:/tmp/ovs-offline-dbg/var-run/ovs/ovs.sock
```

Also, it collects OVN databases from SOS reports.

Fixes: #33 