### PR TITLE
Ofparse: several odp parsing fixes

### DIFF
--- a/bin/offline-dbg
+++ b/bin/offline-dbg
@@ -185,7 +185,7 @@ do_start() {
 print_tools() {
     echo "Working directory: $WORKDIR:"
 
-    if [ $(find $VAR_RUN -name "ovs-vswitchd.*.ctl") ]; then
+    if ls -x $VAR_RUN/ovs-vswitchd.*.ctl &>/dev/null; then
         vswitchd_ctl=$(ls -x $VAR_RUN/ovs-vswitchd.*.ctl)
         echo ""
         echo "openvswitch control found at ${vswitchd_ctl}"
@@ -193,7 +193,7 @@ print_tools() {
         echo "   ovs-appctl --target=${vswitchd_ctl} [...]"
     fi
 
-    if [ $(find $VAR_RUN -name "db.sock") ]; then
+    if ls -x $VAR_RUN/db.sock &>/dev/null; then
         ovsdb_sock=$(ls -x $VAR_RUN/db.sock)
         echo ""
         echo "OVSDB socket found at ${ovsdb_sock}"
@@ -204,7 +204,7 @@ print_tools() {
         echo "   ovsdb-client ${ovsdb_sock} [...]"
     fi
 
-    if [ $(find $VAR_RUN -name "*mgmt") ]; then
+    if ls -x $VAR_RUN/*.mgmt &>/dev/null; then
         ofproto_socks=$(ls -x $VAR_RUN/*.mgmt)
         echo ""
         echo "openflow bridge management sockets found at ${ofproto_socks}"

--- a/ovs_dbg/decoders.py
+++ b/ovs_dbg/decoders.py
@@ -124,7 +124,12 @@ class IntMask(Decoder):
         return "%s('%s')" % (self.__class__.__name__, self)
 
     def __eq__(self, other):
-        return self.value == other.value and self.mask == other.mask
+        if isinstance(other, IntMask):
+            return self.value == other.value and self.mask == other.mask
+        elif isinstance(other, int):
+            return self.value == other and self.mask == self.max_mask()
+        else:
+            raise ValueError("Cannot compare against ", other)
 
     def __contains__(self, other):
         if isinstance(other, IntMask):
@@ -177,7 +182,6 @@ def decode_mask(mask_size):
         __name__ = "Mask{}".format(size)
 
     return Mask
-
 
 
 class EthMask(Decoder):

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     project_urls={
         "Source": "https://github.com/amorenoz/ovs-dbg",
     },
-    version="0.0.8",
+    version="0.0.9",
     zip_safe=False,
 )

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -3,7 +3,7 @@ import pytest
 
 from ovs_dbg.odp import ODPFlow
 from ovs_dbg.kv import KeyValue
-from ovs_dbg.decoders import EthMask, IPMask, Mask32, Mask16, Mask8, Mask128
+from ovs_dbg.decoders import EthMask, IPMask, Mask32, Mask16, Mask8, Mask64, Mask128
 
 
 @pytest.mark.parametrize(
@@ -40,12 +40,12 @@ from ovs_dbg.decoders import EthMask, IPMask, Mask32, Mask16, Mask8, Mask128
                 KeyValue(
                     "tunnel",
                     {
-                        "geneve": {
+                        "geneve": [{
                             "class": Mask16("0"),
                             "type": Mask8("0"),
                             "len": Mask8("4"),
                             "data": Mask128("0xa/0xff"),
-                        },
+                        }],
                         "vxlan": {"flags": 0x800000, "vni": 0x1C7},
                         "erspan": {"ver": 2, "dir": 1, "hwid": 0x1},
                     },
@@ -404,12 +404,12 @@ def test_odp_fields(input_string, expected):
                             "geneve": {
                                 "crit": True,
                                 "vni": 0x1C7,
-                                "options": {
+                                "options": [{
                                     "class": 0xFFFF,
                                     "type": 0x80,
                                     "len": 4,
                                     "data": 0xA,
-                                },
+                                }],
                             }
                         }
                     },


### PR DESCRIPTION


output_ports: can be strings, so use decode_default
geneve: can contain multiple options concatenated
    geneve({...}{...})
samples: rate is a float, not int
tunnel: use masks

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>