### PR TITLE
Add missing ovs-dbg-complete

### DIFF
--- a/bin/ovs-dbg-complete
+++ b/bin/ovs-dbg-complete
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from sys import prefix
+from pkg_resources import resource_filename
+from os import listdir
+from os.path import abspath, join
+
+
+def get_completion_files():
+    completion_dir = abspath(join(resource_filename(__name__, ""), "..", "extras"))
+    return [
+        join(completion_dir, filename)
+        for filename in listdir(completion_dir)
+        if "completion.bash" in filename
+    ]
+
+
+if __name__ == "__main__":
+    for completion_file in get_completion_files():
+        with open(completion_file) as f:
+            print(f.read())


### PR DESCRIPTION
Adding ovs-dbg-complete (my intention was to add it in #41 ) allows users to quickly source all autocomplete scripts

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>