### PR TITLE
ofp_act: support src specification in load action

### DIFF
--- a/ovs_dbg/ofp_act.py
+++ b/ovs_dbg/ofp_act.py
@@ -96,7 +96,12 @@ def decode_load_field(value):
     if len(parts) != 2:
         raise ValueError("Malformed load action : %s" % value)
 
-    return {"value": int(parts[0], 0), "dst": decode_field(parts[1])}
+    # If the load action is performed within a learn() action,
+    # The value can be specified as another field.
+    try:
+        return {"value": int(parts[0], 0), "dst": decode_field(parts[1])}
+    except ValueError:
+        return {"src": decode_field(parts[0]), "dst": decode_field(parts[1])}
 
 
 def decode_set_field(field_decoders, value):

--- a/tests/test_ofp.py
+++ b/tests/test_ofp.py
@@ -128,6 +128,22 @@ from ovs_dbg.decoders import EthMask, IPMask
             ],
         ),
         (
+            "actions=learn(load:NXM_NX_TUN_ID[]->NXM_NX_TUN_ID[])",
+            [
+                KeyValue(
+                    "learn",
+                    [
+                        {
+                            "load": {
+                                "src": {"field": "NXM_NX_TUN_ID"},
+                                "dst": {"field": "NXM_NX_TUN_ID"},
+                            }
+                        }
+                    ],
+                ),
+            ],
+        ),
+        (
             "actions=set_field:00:11:22:33:44:55->eth_src",
             [
                 KeyValue(


### PR DESCRIPTION
Load action ususaly has the format:

    load:value->dst

where "value" get's decoded as integer and "dst" as a field.

However, within the learn action it can be specified as:

    load:src->dst

Where "src" is also a field.

Add support for the later format

Fixes #49 

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>