### PR TITLE
Fix filtering on nested values

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -3,6 +3,7 @@ import pytest
 from ovs_dbg.kv import KeyValue
 from ovs_dbg.filter import OFFilter
 from ovs_dbg.ofp import OFPFlow
+from ovs_dbg.odp import ODPFlow
 
 
 @pytest.mark.parametrize(
@@ -165,6 +166,30 @@ from ovs_dbg.ofp import OFPFlow
             ),
             True,
             ["dl_src", "tp_dst"],
+        ),
+        (
+            "encap",
+            ODPFlow.from_string(
+                "encap(eth_type(0x0800),ipv4(src=10.76.23.240/255.255.255.248,dst=10.76.23.106,proto=17,tos=0/0,ttl=64,frag=no)) actions:drop"
+            ),
+            True,
+            ["encap"],
+        ),
+        (
+            "encap.ipv4.src=10.76.23.240",
+            ODPFlow.from_string(
+                "encap(eth_type(0x0800),ipv4(src=10.76.23.240/255.255.255.248,dst=10.76.23.106,proto=17,tos=0/0,ttl=64,frag=no)) actions:drop"
+            ),
+            False,
+            ["encap"],
+        ),
+        (
+            "encap.ipv4.src~=10.76.23.240",
+            ODPFlow.from_string(
+                "encap(eth_type(0x0800),ipv4(src=10.76.23.240/255.255.255.248,dst=10.76.23.106,proto=17,tos=0/0,ttl=64,frag=no)) actions:drop"
+            ),
+            True,
+            ["encap"],
         ),
     ],
 )


### PR DESCRIPTION
On nested values (dictionaries) we traverse them to find the right key
for evaluation so that an expression like "key1.key2.key3=value" works.

They key is found correctly but the evaluation is performed against the
global value. Fix by making _find_data_in_kv return a tuple (kv, data)
on successful match

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>