### PR TITLE
ovs-offline: fix ovsdb-client print-tools

### DIFF
--- a/bin/ovs-offline
+++ b/bin/ovs-offline
@@ -380,7 +380,7 @@ print_tools() {
             echo "  You can run commands such as:"
             echo "      ${command} --db unix:${db_sock} [...]"
             echo "  or"
-            echo "      ovsdb-client ${db_sock} [...]"
+            echo "      ovsdb-client [...] unix:${db_sock} "
         fi
     done
 


### PR DESCRIPTION
I have found that I need to specify the command and 'unix:' prior to the database socket in order to run ovsdb-client offline on ovs/ovn.

Signed-off-by: Salvatore Daniele <sdaniele@redhat.com>