### PR TITLE
ofp: set size of vlan_vid field to 13

### DIFF
--- a/ovs_dbg/ofp.py
+++ b/ovs_dbg/ofp.py
@@ -146,7 +146,15 @@ class OFPFlow(Flow):
             "mplsm",
         ]
 
-        return {**field_decoders, **{key: decode_flag for key in shorthands}}
+        fields = {**field_decoders, **{key: decode_flag for key in shorthands}}
+
+        # vlan_vid field is special. Although it is technically 12 bit wide,
+        # bit 12 is allowed to be set to 1 to indicate that the vlan header is
+        # present (see section VLAN FIELDS in
+        # http://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt)
+        # Therefore, override the generated vlan_vid field size
+        fields["vlan_vid"] = decode_mask(13)
+        return fields
 
     @classmethod
     def _output_actions_decoders(cls):

--- a/tests/test_ofp.py
+++ b/tests/test_ofp.py
@@ -3,7 +3,7 @@ import pytest
 
 from ovs_dbg.ofp import OFPFlow
 from ovs_dbg.kv import KeyValue
-from ovs_dbg.decoders import EthMask, IPMask
+from ovs_dbg.decoders import EthMask, IPMask, decode_mask
 
 
 @pytest.mark.parametrize(
@@ -165,6 +165,18 @@ from ovs_dbg.decoders import EthMask, IPMask
                             "eth_src": EthMask("01:00:00:00:00:00/01:00:00:00:00:00")
                         },
                         "dst": {"field": "eth_src"},
+                    },
+                )
+            ],
+        ),
+        (
+            "actions=set_field:0x10ff->vlan_vid",
+            [
+                KeyValue(
+                    "set_field",
+                    {
+                        "value": {"vlan_vid": decode_mask(13)("0x10ff")},
+                        "dst": {"field": "vlan_vid"},
                     },
                 )
             ],


### PR DESCRIPTION
Although the meta-flow says it's 12 bit wide, in reality the VLANV_VID
field can hold a 13 bit value because bit 12 expresses the presense of
vlan header in certain OpenFlow versions (see
http://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt)

Therefore, override the vlan_vid length so that the parser does not fail
when it encounters this 13bit wide vlan_vid fields

Fixes: #37 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>