### PR TITLE
ofparse: Support multi-file online flow visualization

### DIFF
--- a/containers/k8s-ofparse/Dockerfile
+++ b/containers/k8s-ofparse/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/fedora/fedora:33-x86_64
+
+RUN dnf install -y git jq python3-pip python3 openvswitch ovn && dnf clean all && rm -rf /var/cache/dnf/*
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN mv kubectl /usr/local/bin
+RUN chmod +x /usr/local/bin/kubectl
+
+ADD . /root/ovs-dbg
+WORKDIR /root/ovs-dbg
+RUN python3 -m pip install .
+
+WORKDIR /root
+ADD containers/k8s-ofparse/monitor.sh /root/
+ENTRYPOINT ["/root/monitor.sh"]
+

--- a/containers/k8s-ofparse/monitor.sh
+++ b/containers/k8s-ofparse/monitor.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -mx
+
+BRIDGE="br-int" # TODO other bridges
+PORT=16640
+BASE_DIR=/tmp/k8s-ofparse
+
+client_stop() {
+  echo "=============== k8-ovs-flowparse client stop ==============="
+  ovs-vsctl del-controller $BRIDGE
+}
+
+client_start() {
+  echo "=============== k8-ovs-flowparse client start ==============="
+  ovs-vsctl set-controller $BRIDGE ptcp:$PORT
+  exec sleep infinity
+}
+
+# Returns the filename where a node's flows shall be synchronized
+_filename() {
+    local node=$1
+    echo ${BASE_DIR}/${node}.flows
+}
+
+monitor() {
+  echo "=============== k8-ovs-flowparse monitor start ==============="
+    mkdir -p ${BASE_DIR}
+    declare -A nodes
+    local ofparse_args=""
+    for node in $(kubectl get nodes -o name); do
+        node_name=${node#"node/"}
+        file=$(_filename ${node_name})
+        ip=$(kubectl get ${node} -o json | jq -r '.status.addresses[] | select(.type == "InternalIP") | .address')
+        nodes[${node_name}]=${ip}
+        ofparse_args="$ofparse_args -i ${node_name},${file}"
+    done
+
+    cat > /usr/local/bin/k8s-ofparse <<EOF
+#!/bin/bash
+
+OFPARSE_ARGS="$ofparse_args"
+exec ofparse \$OFPARSE_ARGS \$@
+EOF
+    chmod +x /usr/local/bin/k8s-ofparse
+
+    cat > /etc/motd <<EOF
+==============================
+        k8s-ofparse
+==============================
+
+The flows from the following nodes are being synchronized into files ({Node Name} ==> {File Path}):
+
+EOF
+
+    for node in "${!nodes[@]}"; do
+        echo " - ${node}  ==>  $(_filename ${node})" >> /etc/motd
+    done
+    cat >> /etc/motd <<EOF
+
+You can use "ofparse -i {filename} ..." to look at any individual node
+Also, you can use "k8s-ofparse ..." to look at all the nodes
+
+Please report bugs or RFEs to https://github.com/amorenoz/ovs-dbg
+
+
+EOF
+
+    echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /root/.bashrc
+    echo 'export PAGER="less -r"' >> /root/.bashrc
+    echo 'eval "$(ovs-dbg-complete)"' >> /root/.bashrc
+    echo 'eval "complete -o nosort -F _ofparse_completion k8s-ofparse"' >> /root/.bashrc # apply same autocomplete to k8s-ofparse
+
+    while sleep 15; do
+        for node in "${!nodes[@]}"; do
+            target="tcp:${nodes[$node]}:${PORT}"
+            file=$(_filename ${node})
+            ovs-ofctl dump-flows ${target} > ${file}.tmp
+            if [ $? -eq 0 ]; then
+                mv ${file}.tmp ${file}
+                echo "$(date): Updated flows for node ${node}"
+            else
+                echo "ERROR ovs-ofctl fails for node $node"
+            fi
+        done
+    done
+}
+
+cmd=${1:-""}
+case ${cmd} in
+"start")
+  monitor
+  ;;
+"client_start")
+  client_start
+  ;;
+"client_stop")
+  client_stop
+  ;;
+"*")
+  echo "Command not supported: ${cmd}"
+  exit 1
+esac

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,8 @@ This respository stores scripts and documentation to help debug OVS and OVN.
 
    lgrep
 
+   k8s-ofparse
+
 .. toctree::
    :maxdepth: 1
    :caption: Tutorials:

--- a/docs/source/k8s-ofparse.rst
+++ b/docs/source/k8s-ofparse.rst
@@ -1,0 +1,68 @@
+===============================================
+k8s-ofparse: Online flow analysis in Kubernetes
+===============================================
+
+k8s-ofparse is essentially a container a Kubernetes deployment manifest.
+
+It deploys two main components:
+
+- k8s-ofparse client: is a daemonset that is deployed on every node. It exposes the openflow control interface of the local br-int on the NODE_IP
+- k8s-ofparse monitor: is a pod that uses "ovs-ofctl" to synchronize the flows from all the nodes into files so you can run ofparse_ on it.
+
+
+
+.. _ofparse: ofparse.html
+
+Diagram
+*******
+
+
+::
+
+              ┌───────────────────┐
+              │    ovn control    │
+              │                   │
+              │ ┌───────────────┐ │
+              │ │ k8s-ofparse   │ │
+              │ │    monitor    │ │
+              └─┴────┬─────┬────┴─┘
+                     │     │
+           ┌─────────┘     └──────────┐
+           │                          │
+           │NODE_IP:16440             │NODE_IP:16440
+    ┌─┬────┴────────┬───┐   ┌───┬─────┴───────┬─┐
+    │ │ k8s-ofparse │   │   │   │ k8s-ofparse │ │
+    │ │   client    │   │   │   │   client    │ │
+    │ │             │   │   │   │             │ │
+    │ └─────────────┘   │   │   └─────────────┘ │   ...
+    │                   │   │                   │
+    │ ┌────────────┐    │   │   ┌───────────┐   │
+    │ │  br-int    │    │   │   │ br-int    │   │
+    │ └────────────┘    │   │   └───────────┘   │
+    │                   │   │                   │
+    └───────────────────┘   └───────────────────┘
+
+
+Usage
+*****
+
+::
+
+    $ kubectl apply -f k8s/k8s-ofparse.yaml
+    $ kubectl exec -it k8s-ofparse-main -- bash
+    ==============================
+            k8s-ofparse
+    ==============================
+
+    The flows from the following nodes are being synchronized into files ({Node Name} ==> {File Path}):
+
+     - ovn-worker2  ==>  /tmp/k8s-ofparse/ovn-worker2.flows
+     - ovn-control-plane  ==>  /tmp/k8s-ofparse/ovn-control-plane.flows
+     - ovn-worker  ==>  /tmp/k8s-ofparse/ovn-worker.flows
+
+    You can use "ofparse -i {filename} ..." to look at any individual node
+    Also, you can use "k8s-ofparse ..." to look at all the nodes
+
+    Please report bugs or RFEs to https://github.com/amorenoz/ovs-dbg
+
+

--- a/docs/source/ofparse.rst
+++ b/docs/source/ofparse.rst
@@ -10,6 +10,44 @@ It parses a list of OpenFlow commands (such as the ones that `ovs-ofproto dump-f
 `ovs-dpctl dump-flows` would generate) prints them back in the following formats
 
 
+-----
+Usage
+-----
+
+::
+
+    Usage: ofparse [OPTIONS] TYPE
+
+      OpenFlow Parse utility.
+
+      It parses openflow and datapath flows (such as the output of ovs-ofctl dump-
+      flows or ovs-appctl dpctl/dump-flows) and prints them in different formats.
+
+    Options:
+      -c, --config PATH     Use config file  [default: /home/amorenoz/code/ovs-
+                            dbg/ovs_dbg/ofparse/etc/ofparse.conf]
+      --style TEXT          Select style (defined in config file)
+      -i, --input TEXT      Read flows from specified filepath. If not provided,
+                            flows will be read from stdin. This option can be
+                            specified multiple times. Format [alias,]FILENAME.
+                            Where alias is a name that shall be used to refer to
+                            this FILENAME
+      -p, --paged           Page the result (uses $PAGER). If colors are not
+                            disabled you might need to enable colors on your
+                            PAGER, eg: export PAGER="less -r".  [default: False]
+      -f, --filter TEXT     Filter flows that match the filter expression. Run
+                            'ofparse filter'for a detailed description of the
+                            filtering syntax
+      -l, --highlight TEXT  Highlight flows that match the filter expression. Run
+                            'ofparse filter'for a detailed description of the
+                            filtering syntax
+      -h, --help            Show this message and exit.
+
+    Commands:
+      datapath  Process DPIF Flows
+      openflow  Process OpenFlow Flows
+
+
 -------------------
 JSON representation
 -------------------

--- a/k8s/k8s-ofparse.yaml
+++ b/k8s/k8s-ofparse.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: k8s-ofparse-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: list-nodes
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-ofparse-binding
+subjects:
+  - kind: ServiceAccount
+    name: k8s-ofparse-account
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: list-nodes
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Monitor pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k8s-ofparse-main
+spec:
+  nodeSelector:
+    k8s.ovn.org/ovnkube-db: "true"
+  serviceAccountName: k8s-ofparse-account
+  hostNetwork: true
+  volumes:
+    - name: host-var-run-ovs
+      hostPath:
+        path: /var/run/openvswitch
+  containers:
+  - name: k8s-ofparse
+    image: quay.io/amorenoz/k8s-ofparse
+    #imagePullPolicy: Always
+    volumeMounts:
+      - mountPath: /var/run/openvswitch/
+        name: host-var-run-ovs
+    env:
+      - name: OVN_RUNDIR
+        value: "/var/run/openvswitch"
+      - name: OVS_RUNDIR
+        value: "/var/run/openvswitch"
+    command: ["/root/monitor.sh", "start"]
+
+---
+# Client daemonsets
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8s-ofparse-client
+spec:
+  selector:
+    matchLabels:
+      app: k8s-ofparse
+  template:
+    metadata:
+      labels:
+        app: k8s-ofparse
+        name: k8s-ofparse
+    spec:
+      hostNetwork: true
+      volumes:
+        - name: host-var-run-ovs
+          hostPath:
+            path: /var/run/openvswitch
+      containers:
+      - name: k8s-ofparse
+        image: quay.io/amorenoz/k8s-ofparse
+        #imagePullPolicy: Always
+        volumeMounts:
+          - mountPath: /var/run/openvswitch/
+            name: host-var-run-ovs
+        env:
+          - name: OVS_RUNDIR
+            value: "/var/run/openvswitch"
+        command: ["/root/monitor.sh", "client_start"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/monitor.sh", "client_stop"]
+

--- a/ovs_dbg/ofp.py
+++ b/ovs_dbg/ofp.py
@@ -79,6 +79,9 @@ class OFPFlowFactory:
         :return: an OFPFlow with the content of the flow string
         :rtype: OFPFlow
         """
+        if " reply " in ofp_string:
+            return None
+
         sections = list()
         parts = ofp_string.split("actions=")
         if len(parts) != 2:

--- a/ovs_dbg/ofparse/console.py
+++ b/ovs_dbg/ofparse/console.py
@@ -10,8 +10,24 @@ from rich.console import Console
 from rich.text import Text
 from rich.style import Style
 from rich.color import Color
+from rich.panel import Panel
+from rich.emoji import Emoji
 
 from ovs_dbg.ofparse.format import FlowFormatter, FlowBuffer, FlowStyle
+
+
+def file_header(name):
+    return Panel(
+        Text(
+            Emoji.replace(":scroll:")
+            + " "
+            + name
+            + " "
+            + Emoji.replace(":scroll:"),
+            style="bold",
+            justify="center",
+        )
+    )
 
 
 class ConsoleBuffer(FlowBuffer):

--- a/ovs_dbg/ofparse/dp_tree.py
+++ b/ovs_dbg/ofparse/dp_tree.py
@@ -52,7 +52,7 @@ class FlowTree:
     root = None
 
     def __init__(self, flows=None):
-        self._flows = {}  # flow list indexed by recirc_id
+        self._flows = flows or {}  # flow list indexed by recirc_id
         self.root = self.root or TreeElem(is_root=True)
 
     def add(self, flow):

--- a/ovs_dbg/ofparse/html.py
+++ b/ovs_dbg/ofparse/html.py
@@ -110,13 +110,6 @@ class HTMLFormatter(FlowFormatter):
         self.style = (
             self._style_from_opts(opts, "html", HTMLStyle) or FlowStyle()
         )
-        self.style.set_value_style(
-            "resubmit",
-            HTMLStyle(
-                self.style.get("value.resubmit"),
-                anchor_gen=lambda x: "#table_{}".format(x.value["table"]),
-            ),
-        )
 
     def format_flow(self, buf, flow, highlighted=None):
         """

--- a/ovs_dbg/ofparse/ofp.py
+++ b/ovs_dbg/ofparse/ofp.py
@@ -1,30 +1,17 @@
 import click
-from rich.tree import Tree
-from rich.text import Text
-from rich.console import Console
 
 from ovs_dbg.ofp import OFPFlowFactory
+from ovs_dbg.ofparse.ofp_logic import LogicFlowProcessor
 from ovs_dbg.ofparse.main import maincli
-from ovs_dbg.ofparse.process import process_flows, tojson
-from ovs_dbg.ofparse.console import (
-    ConsoleBuffer,
-    ConsoleFormatter,
-    hash_pallete,
-    heat_pallete,
-    print_context,
+from ovs_dbg.ofparse.process import (
+    FlowProcessor,
+    JSONProcessor,
+    ConsoleProcessor,
 )
-from ovs_dbg.ofparse.html import HTMLBuffer, HTMLFormatter
+from ovs_dbg.ofparse.html import HTMLBuffer, HTMLFormatter, HTMLStyle
 
 
 factory = OFPFlowFactory()
-
-# Try to make it easy to spot same cookies by printing them in different
-# colors
-cookie_style_gen = hash_pallete(
-    hue=[x / 10 for x in range(0, 10)],
-    saturation=[0.5],
-    value=[0.5 + x / 10 * (0.85 - 0.5) for x in range(0, 10)],
-)
 
 
 @maincli.group(subcommand_metavar="FORMAT")
@@ -38,7 +25,9 @@ def openflow(opts):
 @click.pass_obj
 def json(opts):
     """Print the flows in JSON format"""
-    return tojson(flow_factory=create_ofp_flow, opts=opts)
+    proc = JSONProcessor(opts, factory)
+    proc.process()
+    print(proc.json_string())
 
 
 @openflow.command()
@@ -53,35 +42,11 @@ def json(opts):
 @click.pass_obj
 def pretty(opts, heat_map):
     """Print the flows with some style"""
-    flows = list()
-
-    def callback(flow):
-        """Parse the flows and sort them by table"""
-        flows.append(flow)
-
-    process_flows(
-        flow_factory=create_ofp_flow,
-        callback=callback,
-        filename=opts.get("filename"),
-        filter=opts.get("filter"),
+    proc = ConsoleProcessor(
+        opts, factory, heat_map=["n_packets", "n_bytes"] if heat_map else []
     )
-
-    console = ConsoleFormatter(opts)
-    if heat_map and len(flows) > 0:
-        for field in ["n_packets", "n_bytes"]:
-            values = [f.info.get(field) or 0 for f in flows]
-            console.style.set_value_style(
-                field, heat_pallete(min(values), max(values))
-            )
-
-    for flow in flows:
-        high = None
-        if opts.get("highlight"):
-            result = opts.get("highlight").evaluate(flow)
-            if result:
-                high = result.kv
-        with print_context(console.console, opts):
-            console.print_flow(flow, high)
+    proc.process()
+    proc.print()
 
 
 @openflow.command()
@@ -123,229 +88,74 @@ def logic(opts, show_flows, cookie_flag, heat_map):
     Optionally, the cookie can also be considered to be part of the logical
     flow.
     """
-    tables = dict()
+    processor = LogicFlowProcessor(opts, factory, cookie_flag)
+    processor.process()
+    processor.print(show_flows, heat_map)
 
-    class LFlow:
-        """A Logical Flow represents the scheleton of a flow
 
-        Attributes:
-            flow (OFPFlow): The flow
-            match_action_keys(list): Optional; list of action keys that are
-                mathched exactly (not just the key but the value also)
-            match_cookie (bool): Optional; if cookies are part of the logical
-                flow
-        """
+class HTMLProcessor(FlowProcessor):
+    def __init__(self, opts, factory):
+        super().__init__(opts, factory)
+        self.data = dict()
 
-        def __init__(self, flow, match_action_keys=[], match_cookie=False):
-            self.cookie = (
-                flow.info.get("cookie") or 0 if match_cookie else None
-            )
-            self.priority = flow.match.get("priority") or 0
-            self.match_keys = tuple([kv.key for kv in flow.match_kv])
+    def start_file(self, name, filename):
+        self.tables = dict()
 
-            self.action_keys = tuple(
-                [
-                    kv.key
-                    for kv in flow.actions_kv
-                    if kv.key not in match_action_keys
-                ]
-            )
-            self.match_action_kvs = [
-                kv for kv in flow.actions_kv if kv.key in match_action_keys
-            ]
+    def stop_file(self, name, filename):
+        self.data[name] = self.tables
 
-        def __eq__(self, other):
-            return (
-                (self.cookie == other.cookie if self.cookie else True)
-                and self.priority == other.priority
-                and self.action_keys == other.action_keys
-                and self.equal_match_action_kvs(other)
-                and self.match_keys == other.match_keys
-            )
-
-        def equal_match_action_kvs(self, other):
-            """
-            Compares the logical flow's match action key-values with the
-            other's
-            Args:
-                other (LFlow): The other LFlow to compare against
-
-            Returns true if both LFlow have the same action k-v
-            """
-            if len(other.match_action_kvs) != len(self.match_action_kvs):
-                return False
-
-            for kv in self.match_action_kvs:
-                found = False
-                for other_kv in other.match_action_kvs:
-                    if self.match_kv(kv, other_kv):
-                        found = True
-                        break
-                if not found:
-                    return False
-            return True
-
-        def match_kv(self, one, other):
-            """Compares a KeyValue
-            Args:
-                one, other (KeyValue): The objects to compare
-
-            Returns true if both KeyValue objects have the same key and value
-            """
-            return one.key == other.key and one.value == other.value
-
-        def __hash__(self):
-            hash_data = [
-                self.cookie,
-                self.priority,
-                self.action_keys,
-                tuple((kv.key, str(kv.value)) for kv in self.match_action_kvs),
-                self.match_keys,
-            ]
-            if self.cookie:
-                hash_data.append(self.cookie)
-            return tuple(hash_data).__hash__()
-
-        def format(self, buf):
-            """Format the Logical Flow into a Buffer"""
-            formatter = ConsoleFormatter(opts)
-
-            if self.cookie:
-                buf.append_extra(
-                    "cookie={} ".format(hex(self.cookie)).ljust(18),
-                    style=cookie_style_gen(str(self.cookie)),
-                )
-
-            buf.append_extra(
-                "priority={} ".format(self.priority), style="steel_blue"
-            )
-            buf.append_extra(",".join(self.match_keys), style="steel_blue")
-            buf.append_extra("  --->  ", style="bold magenta")
-            buf.append_extra(",".join(lflow.action_keys), style="steel_blue")
-
-            if len(self.match_action_kvs) > 0:
-                buf.append_extra(" ", style=None)
-
-            for kv in self.match_action_kvs:
-                formatter.format_kv(buf, kv, formatter.style)
-                buf.append_extra(",", style=None)
-
-    def callback(flow):
-        """Parse the flows and sort them by table and logical flow"""
+    def process_flow(self, flow, name):
         table = flow.info.get("table") or 0
-        if not tables.get(table):
-            tables[table] = dict()
+        if not self.tables.get(table):
+            self.tables[table] = list()
+        self.tables[table].append(flow)
 
-        # Group flows by logical hash
-        lflow = LFlow(
-            flow,
-            match_action_keys=["output", "resubmit", "drop"],
-            match_cookie=cookie_flag,
-        )
+    def html(self):
+        html_obj = ""
+        for name, tables in self.data.items():
+            name = name.replace(" ", "_")
+            html_obj += "<h1>{}</h1>".format(name)
+            html_obj += "<div id=flow_list>"
+            for table, flows in tables.items():
+                formatter = HTMLFormatter(self.opts)
 
-        if not tables[table].get(lflow):
-            tables[table][lflow] = list()
+                def anchor(x):
+                    return "#table_%s_%s" % (name, x.value["table"])
 
-        tables[table][lflow].append(flow)
-
-    process_flows(
-        flow_factory=create_ofp_flow,
-        callback=callback,
-        filename=opts.get("filename"),
-        filter=opts.get("filter"),
-    )
-
-    tree = Tree("Ofproto Flows (logical)")
-    console = Console(color_system=None if opts["style"] is None else "256")
-    formatter = ConsoleFormatter(opts=opts, console=console)
-
-    for table_num in sorted(tables.keys()):
-        table = tables[table_num]
-        table_tree = tree.add("** TABLE {} **".format(table_num))
-
-        if heat_map:
-            for field in ["n_packets", "n_bytes"]:
-                values = []
-                for flow_list in table.values():
-                    values.extend([f.info.get(field) or 0 for f in flow_list])
                 formatter.style.set_value_style(
-                    field, heat_pallete(min(values), max(values))
+                    "resubmit",
+                    HTMLStyle(
+                        formatter.style.get("value.resubmit"),
+                        anchor_gen=anchor,
+                    ),
                 )
-
-        for lflow in sorted(
-            table.keys(),
-            key=(lambda x: x.priority),
-            reverse=True,
-        ):
-            flows = table[lflow]
-
-            buf = ConsoleBuffer(Text())
-
-            lflow.format(buf)
-            buf.append_extra(
-                " ( x {} )".format(len(flows)), style="dark_olive_green3"
-            )
-            lflow_tree = table_tree.add(buf.text)
-
-            if show_flows:
+                html_obj += (
+                    "<h2 id=table_{name}_{table}> Table {table}</h2>".format(
+                        name=name, table=table
+                    )
+                )
+                html_obj += "<ul id=table_{}_flow_list>".format(table)
                 for flow in flows:
-                    buf = ConsoleBuffer(Text())
+                    html_obj += "<li id=flow_{}>".format(flow.id)
                     highlighted = None
-                    if opts.get("highlight"):
-                        result = opts.get("highlight").evaluate(flow)
+                    if self.opts.get("highlight"):
+                        result = self.opts.get("highlight").evaluate(flow)
                         if result:
                             highlighted = result.kv
+                    buf = HTMLBuffer()
                     formatter.format_flow(buf, flow, highlighted)
-                    lflow_tree.add(buf.text)
+                    html_obj += buf.text
+                    html_obj += "</li>"
+                html_obj += "</ul>"
+            html_obj += "</div>"
 
-    with print_context(console, opts):
-        console.print(tree)
+        return html_obj
 
 
 @openflow.command()
 @click.pass_obj
 def html(opts):
     """Print the flows in an HTML list"""
-    tables = dict()
-
-    def callback(flow):
-        """Parse the flows and sort them by table"""
-        table = flow.info.get("table") or 0
-        if not tables.get(table):
-            tables[table] = list()
-        tables[table].append(flow)
-
-    process_flows(
-        flow_factory=create_ofp_flow,
-        callback=callback,
-        filename=opts.get("filename"),
-        filter=opts.get("filter"),
-    )
-
-    html_obj = "<div id=flow_list>"
-    for table, flows in tables.items():
-        html_obj += "<h2 id=table_{table}> Table {table}</h2>".format(
-            table=table
-        )
-        html_obj += "<ul id=table_{}_flow_list>".format(table)
-        for flow in flows:
-            html_obj += "<li id=flow_{}>".format(flow.id)
-            highlighted = None
-            if opts.get("highlight"):
-                result = opts.get("highlight").evaluate(flow)
-                if result:
-                    highlighted = result.kv
-            buf = HTMLBuffer()
-            HTMLFormatter(opts).format_flow(buf, flow, highlighted)
-            html_obj += buf.text
-            html_obj += "</li>"
-        html_obj += "</ul>"
-    html_obj += "</div>"
-    print(html_obj)
-
-
-def create_ofp_flow(string, idx):
-    """Create a OFPFlow"""
-    if " reply " in string:
-        return None
-    return factory.from_string(string, idx)
+    processor = HTMLProcessor(opts, factory)
+    processor.process()
+    print(processor.html())

--- a/ovs_dbg/ofparse/ofp_logic.py
+++ b/ovs_dbg/ofparse/ofp_logic.py
@@ -1,0 +1,210 @@
+from rich.tree import Tree
+from rich.text import Text
+from rich.console import Console
+
+from ovs_dbg.ofparse.process import FlowProcessor
+from ovs_dbg.ofparse.console import (
+    ConsoleFormatter,
+    ConsoleBuffer,
+    hash_pallete,
+    file_header,
+    heat_pallete,
+    print_context,
+)
+
+# Try to make it easy to spot same cookies by printing them in different
+# colors
+cookie_style_gen = hash_pallete(
+    hue=[x / 10 for x in range(0, 10)],
+    saturation=[0.5],
+    value=[0.5 + x / 10 * (0.85 - 0.5) for x in range(0, 10)],
+)
+
+
+class LFlow:
+    """A Logical Flow represents the scheleton of a flow
+
+    Attributes:
+        flow (OFPFlow): The flow
+        match_action_keys(list): Optional; list of action keys that are
+            mathched exactly (not just the key but the value also)
+        match_cookie (bool): Optional; if cookies are part of the logical
+            flow
+    """
+
+    def __init__(self, flow, match_action_keys=[], match_cookie=False):
+        self.cookie = flow.info.get("cookie") or 0 if match_cookie else None
+        self.priority = flow.match.get("priority") or 0
+        self.match_keys = tuple([kv.key for kv in flow.match_kv])
+
+        self.action_keys = tuple(
+            [
+                kv.key
+                for kv in flow.actions_kv
+                if kv.key not in match_action_keys
+            ]
+        )
+        self.match_action_kvs = [
+            kv for kv in flow.actions_kv if kv.key in match_action_keys
+        ]
+
+    def __eq__(self, other):
+        return (
+            (self.cookie == other.cookie if self.cookie else True)
+            and self.priority == other.priority
+            and self.action_keys == other.action_keys
+            and self.equal_match_action_kvs(other)
+            and self.match_keys == other.match_keys
+        )
+
+    def equal_match_action_kvs(self, other):
+        """
+        Compares the logical flow's match action key-values with the other's
+        Args:
+            other (LFlow): The other LFlow to compare against
+
+        Returns true if both LFlow have the same action k-v
+        """
+        if len(other.match_action_kvs) != len(self.match_action_kvs):
+            return False
+
+        for kv in self.match_action_kvs:
+            found = False
+            for other_kv in other.match_action_kvs:
+                if self.match_kv(kv, other_kv):
+                    found = True
+                    break
+            if not found:
+                return False
+        return True
+
+    def match_kv(self, one, other):
+        """Compares a KeyValue
+        Args:
+            one, other (KeyValue): The objects to compare
+
+        Returns true if both KeyValue objects have the same key and value
+        """
+        return one.key == other.key and one.value == other.value
+
+    def __hash__(self):
+        hash_data = [
+            self.cookie,
+            self.priority,
+            self.action_keys,
+            tuple((kv.key, str(kv.value)) for kv in self.match_action_kvs),
+            self.match_keys,
+        ]
+        if self.cookie:
+            hash_data.append(self.cookie)
+        return tuple(hash_data).__hash__()
+
+    def format(self, buf, formatter):
+        """Format the Logical Flow into a Buffer"""
+        if self.cookie:
+            buf.append_extra(
+                "cookie={} ".format(hex(self.cookie)).ljust(18),
+                style=cookie_style_gen(str(self.cookie)),
+            )
+
+        buf.append_extra(
+            "priority={} ".format(self.priority), style="steel_blue"
+        )
+        buf.append_extra(",".join(self.match_keys), style="steel_blue")
+        buf.append_extra("  --->  ", style="bold magenta")
+        buf.append_extra(",".join(self.action_keys), style="steel_blue")
+
+        if len(self.match_action_kvs) > 0:
+            buf.append_extra(" ", style=None)
+
+        for kv in self.match_action_kvs:
+            formatter.format_kv(buf, kv, formatter.style)
+            buf.append_extra(",", style=None)
+
+
+class LogicFlowProcessor(FlowProcessor):
+    def __init__(self, opts, factory, match_cookie):
+        super().__init__(opts, factory)
+        self.data = dict()
+        self.match_cookie = match_cookie
+
+    def start_file(self, name, filename):
+        self.tables = dict()
+
+    def stop_file(self, name, filename):
+        self.data[name] = self.tables
+
+    def process_flow(self, flow, name):
+        """Sort the flows by table and logical flow"""
+        table = flow.info.get("table") or 0
+        if not self.tables.get(table):
+            self.tables[table] = dict()
+
+        # Group flows by logical hash
+        lflow = LFlow(
+            flow,
+            match_action_keys=["output", "resubmit", "drop"],
+            match_cookie=self.match_cookie,
+        )
+
+        if not self.tables[table].get(lflow):
+            self.tables[table][lflow] = list()
+
+        self.tables[table][lflow].append(flow)
+
+    def print(self, show_flows, heat_map):
+        console = Console(
+            color_system=None if self.opts["style"] is None else "256"
+        )
+        formatter = ConsoleFormatter(opts=self.opts, console=console)
+        with print_context(console, self.opts):
+            for name, tables in self.data.items():
+                console.print("\n")
+                console.print(file_header(name))
+                tree = Tree("Ofproto Flows (logical)")
+
+                for table_num in sorted(tables.keys()):
+                    table = tables[table_num]
+                    table_tree = tree.add("** TABLE {} **".format(table_num))
+
+                    if heat_map:
+                        for field in ["n_packets", "n_bytes"]:
+                            values = []
+                            for flow_list in table.values():
+                                values.extend(
+                                    [f.info.get(field) or 0 for f in flow_list]
+                                )
+                            formatter.style.set_value_style(
+                                field, heat_pallete(min(values), max(values))
+                            )
+
+                    for lflow in sorted(
+                        table.keys(),
+                        key=(lambda x: x.priority),
+                        reverse=True,
+                    ):
+                        flows = table[lflow]
+
+                        buf = ConsoleBuffer(Text())
+
+                        lflow.format(buf, formatter)
+                        buf.append_extra(
+                            " ( x {} )".format(len(flows)),
+                            style="dark_olive_green3",
+                        )
+                        lflow_tree = table_tree.add(buf.text)
+
+                        if show_flows:
+                            for flow in flows:
+                                buf = ConsoleBuffer(Text())
+                                highlighted = None
+                                if self.opts.get("highlight"):
+                                    result = self.opts.get(
+                                        "highlight"
+                                    ).evaluate(flow)
+                                    if result:
+                                        highlighted = result.kv
+                                formatter.format_flow(buf, flow, highlighted)
+                                lflow_tree.add(buf.text)
+
+                console.print(tree)

--- a/ovs_dbg/ofparse/process.py
+++ b/ovs_dbg/ofparse/process.py
@@ -2,86 +2,194 @@
 """
 import sys
 import json
+import click
 
 from ovs_dbg.decoders import FlowEncoder
-from ovs_dbg.ofparse.console import ConsoleFormatter, print_context
+from ovs_dbg.ofparse.console import (
+    ConsoleFormatter,
+    print_context,
+    heat_pallete,
+    file_header,
+)
 
 
-def process_flows(flow_factory, callback, filename="", filter=None):
-    """Process flows from file or stdin
+class FlowProcessor(object):
+    """Base class for file-based Flow processing. It is able to create flows
+    from strings found in a file (or stdin).
 
-    Args:
-        flow_factory(Callable): function to call to create a flow
-        callback (Callable): function to call with each processed flow
-        filename (str): Optional; filename to read frows from
-        filter (OFFilter): Optional; filter to use to filter flows
-    """
-    idx = 0
-    if filename:
-        with open(filename) as f:
-            for line in f:
-                flow = flow_factory(line, idx)
-                idx += 1
-                if not flow or (filter and not filter.evaluate(flow)):
-                    continue
-                callback(flow)
-    else:
-        data = sys.stdin.read()
-        for line in data.split("\n"):
-            line = line.strip()
-            if line:
-                flow = flow_factory(line, idx)
-                idx += 1
-                if not flow or (filter and not filter.evaluate(flow)):
-                    continue
-                callback(flow)
+    The process of parsing the flows is extendable in many ways by deriving
+    this class.
 
+    When process() is called, the base class will:
+        - call self.start_file() for each new file that get's processed
+        - call self.create_flow() for each flow line
+        - apply the filter defined in opts if provided (can be optionally
+            disabled)
+        - call self.process_flow() for after the flow has been filtered
+        - call self.stop_file() after the file has been processed entirely
 
-def tojson(flow_factory, opts):
-    """
-    Print the json representation of the flow list
+    In the case of stdin, the filename and file alias is 'stdin'
 
     Args:
-        flow_factory (Callable): Function to call to create the flows
-        opts (dict): Options
+        opts (dict): Options dictionary
+        factory (object): Factory object to use to build flows
+            The factory object must have a function as:
+                from_string(line, idx)
     """
-    flows = []
 
-    def callback(flow):
-        flows.append(flow)
+    def __init__(self, opts, factory):
+        self.opts = opts
+        self.factory = factory
 
-    process_flows(
-        flow_factory, callback, opts.get("filename"), opts.get("filter")
-    )
+    # Methods that must be implemented by derived classes
+    def init(self):
+        """Called before the flow processing begins"""
+        pass
 
-    flow_json = json.dumps(
-        [flow.dict() for flow in flows],
-        indent=4,
-        cls=FlowEncoder,
-    )
+    def start_file(self, alias, filename):
+        """Called before the processing of a file begins
+        Args:
+            alias(str): The alias name of the filename
+            filename(str): The filename string
+        """
+        pass
 
-    print(flow_json)
+    def create_flow(self, line, idx):
+        """Called for each line in the file
+        Args:
+            line(str): The flow line
+            idx(int): The line index
+
+        Returns a Flow
+        """
+        return self.factory.from_string(line, idx)
+
+    def process_flow(self, flow, name):
+        """Called for built flow (after filtering)
+        Args:
+            flow(Flow): The flow created by create_flow
+            name(str): The name of the file from which the flow comes
+        """
+        pass
+
+    def stop_file(self, alias, filename):
+        """Called after the processing of a file ends
+        Args:
+            alias(str): The alias name of the filename
+            filename(str): The filename string
+        """
+        pass
+
+    def end(self):
+        """Called after the processing ends"""
+        pass
+
+    def process(self, do_filter=True):
+        idx = 0
+        filenames = self.opts.get("filename")
+        filt = self.opts.get("filter") if do_filter else None
+        self.init()
+        if filenames:
+            for alias, filename in filenames:
+                try:
+                    with open(filename) as f:
+                        self.start_file(alias, filename)
+                        for line in f:
+                            flow = self.create_flow(line, idx)
+                            idx += 1
+                            if not flow or (filt and not filt.evaluate(flow)):
+                                continue
+                            self.process_flow(flow, alias)
+                        self.stop_file(alias, filename)
+                except IOError as e:
+                    raise click.BadParameter(
+                        "Failed to read from file {} ({}): {}".format(
+                            filename, e.errno, e.strerror
+                        )
+                    )
+        else:
+            data = sys.stdin.read()
+            self.start_file("stdin", "stdin")
+            for line in data.split("\n"):
+                line = line.strip()
+                if line:
+                    flow = self.create_flow(line, idx)
+                    idx += 1
+                    if not flow or (filt and not filt.evaluate(flow)):
+                        continue
+                    self.process_flow(flow, "stdin")
+            self.stop_file("stdin", "stdin")
+        self.end()
 
 
-def pprint(flow_factory, opts):
-    """
-    Pretty print the flows
+class JSONProcessor(FlowProcessor):
+    """A generic JsonProcessor"""
 
-    Args:
-        flow_factory (Callable): Function to call to create the flows
-        opts (dict): Options
-    """
-    console = ConsoleFormatter(opts)
+    def __init__(self, opts, factory):
+        super().__init__(opts, factory)
+        self.flows = dict()
 
-    def callback(flow):
-        high = None
-        if opts.get("highlight"):
-            result = opts.get("highlight").evaluate(flow)
-            if result:
-                high = result.kv
-        console.print_flow(flow, high)
+    def start_file(self, name, filename):
+        self.flows_list = list()
 
-    with print_context(console.console, opts):
-        process_flows(
-            flow_factory, callback, opts.get("filename"), opts.get("filter")
+    def stop_file(self, name, filename):
+        self.flows[name] = self.flows_list
+
+    def process_flow(self, flow, name):
+        self.flows_list.append(flow)
+
+    def json_string(self):
+        if len(self.flows.keys()) > 1:
+            return json.dumps(
+                [
+                    {"name": name, "flows": [flow.dict() for flow in flows]}
+                    for name, flows in self.flows.items()
+                ],
+                indent=4,
+                cls=FlowEncoder,
+            )
+        return json.dumps(
+            [flow.dict() for flow in self.flows_list],
+            indent=4,
+            cls=FlowEncoder,
         )
+
+
+class ConsoleProcessor(FlowProcessor):
+    """A generic Console Processor that prints flows into the console"""
+
+    def __init__(self, opts, factory, heat_map=[]):
+        super().__init__(opts, factory)
+        self.heat_map = heat_map
+        self.console = ConsoleFormatter(opts)
+        self.flows = dict()
+
+    def start_file(self, name, filename):
+        self.flows_list = list()
+
+    def stop_file(self, name, filename):
+        self.flows[name] = self.flows_list
+
+    def process_flow(self, flow, name):
+        self.flows_list.append(flow)
+
+    def print(self):
+        with print_context(self.console.console, self.opts):
+            for name, flows in self.flows.items():
+                self.console.console.print("\n")
+                self.console.console.print(file_header(name))
+
+                if len(self.heat_map) > 0 and len(self.flows) > 0:
+                    for field in self.heat_map:
+                        values = [f.info.get(field) or 0 for f in flows]
+                        self.console.style.set_value_style(
+                            field, heat_pallete(min(values), max(values))
+                        )
+
+                for flow in flows:
+                    high = None
+                    if self.opts.get("highlight"):
+                        result = self.opts.get("highlight").evaluate(flow)
+                        if result:
+                            high = result.kv
+                    self.console.print_flow(flow, high)


### PR DESCRIPTION
This PR adds multi-file support to ofparse. Only some of the formats support multi-input, for instance "datapath graph" does not.

In order to test this feature, a container and some k8s deployment scripts are introduced to enable the visualization of openflow flows in a live k8s cluster.
