### PR TITLE
ovs-offline: build containers from specified ovs repo

### DIFF
--- a/bin/ovs-offline
+++ b/bin/ovs-offline
@@ -12,6 +12,8 @@ SOS_DIR=${WORKDIR}/sos_report
 SOS_CMD_DIR=${SOS_DIR}/sos_commands/openvswitch/
 SOURCE_DIR=${WORKDIR}/bin
 CONTAINER_CMD=docker
+OVS_REPO=${OVS_DBG_REPO:-https://github.com/openvswitch/ovs.git}
+OVS_COMMIT=${OVS_DBG_COMMIT:-branch-2.15}
 
 
 declare -A open_flow_protocols=(
@@ -30,6 +32,10 @@ usage() {
     echo ""
     echo "Basic commands:"
     echo "  build                Builds the needed container images"
+    echo "    Options":
+    echo "       -r:    Set ovs git-repo to clone source code from. Also configurable via OVS_DBG_REPO env var.  Default: ${OVS_REPO}"
+    echo "       -c:    Set commit/branch to git checkout. Also configurable via OVS_DBG_COMMIT env var.         Default: ${OVS_COMMIT}"
+    echo "       -n:    Build without using cache (i.e. to rebuild a repo/branch with new changes)"
     echo ""
     echo "  start                Starts an offline debugging session service. Data must have been previously collected in the working directory"
     echo ""
@@ -52,7 +58,7 @@ usage() {
     echo ""
     echo "Generic options"
     echo "  -h:     Print help"
-    echo "  -w:     Set working directory. Also configurable via OVS_DBG_WORKDIR env var. Default: /tmp/ovs-offline-dbg"
+    echo "  -w:     Set working directory. Also configurable via OVS_DBG_WORKDIR env var. Default: /tmp/ovs-offline"
     echo "  -d:     Set debug mode"
     echo "  -p:     Manage containers using podman (default: Docker)"
 }
@@ -71,12 +77,23 @@ set_container_cmd() {
             error "docker and/or podman must be installed to run ovs-offline"
         fi
     fi
-    echo "running $CONTAINER_CMD"
 }
 
 do_build() {
     set_container_cmd
-    ${CONTAINER_CMD} build -t ovs-dbg -f ${CONTAINER_PATH}/Dockerfile ${CONTAINER_PATH}
+    while getopts "r:c:n" opt; do
+        case ${opt} in
+            r)
+                OVS_REPO=$OPTARG
+                ;;
+            c)
+                OVS_COMMIT=$OPTARG
+                ;;
+            n)
+                local cache_arg=--no-cache
+        esac
+    done
+    ${CONTAINER_CMD} build --build-arg OVS_REPO=${OVS_REPO} --build-arg OVS_COMMIT=${OVS_COMMIT} -t ovs-dbg -f ${CONTAINER_PATH}/Dockerfile ${CONTAINER_PATH} ${cache_arg-}
 }
 
 do_stop() {

--- a/containers/ovs-dbg/Dockerfile
+++ b/containers/ovs-dbg/Dockerfile
@@ -6,12 +6,14 @@ FROM quay.io/fedora/fedora:31-x86_64 as build
 RUN dnf -y install gcc make autoconf automake libtool diffutils file
 RUN dnf -y install libcap-ng-devel openssl-devel libatomic 
 
-ARG OVS_VERSION=v2.15.0
-ADD https://github.com/openvswitch/ovs/archive/${OVS_VERSION}.tar.gz /src/
+RUN dnf -y install git
+
+ARG OVS_REPO=https://github.com/openvswitch/ovs.git
+ARG OVS_COMMIT=branch-2.15
+RUN echo "Building ovs from ${OVS_REPO} at ${OVS_COMMIT}"
 
 WORKDIR /src
-RUN mkdir -p /src/ovs
-RUN tar --strip-components=1 -C ovs -xvf ${OVS_VERSION}.tar.gz
+RUN git clone ${OVS_REPO} && cd ovs && git checkout ${OVS_COMMIT}
 
 WORKDIR /src/ovs
 RUN ./boot.sh

--- a/docs/source/ovs-offline.rst
+++ b/docs/source/ovs-offline.rst
@@ -10,11 +10,11 @@ Usage
 
 In general, the tool works in two steps. First you must **collect** the logs, flows etc, and then you **start** the offline debugging environment
 
-(Optional) Build the ovs-dbg container:
+(Optional) Build the ovs-dbg container. You can choose to specify the ovs-repo and commit to pull the ovs source code from using the -r and -c flags respectively (or by setting the OVS_DBG_REPO and OVS_DBG_COMMIT env variables).
 
 ::
 
-    ./bin/ovs-offline build
+    ./bin/ovs-offline build -r https://github.com/my_repo/ovs.git -c branch-2.15
 
 
 Collect data from a running kubernetes / Openshift cluster


### PR DESCRIPTION
Add build time args to allow for users to specify an
ovs repo and branch to build ovs from via option flags.

Default ovs is changed from:
https://github.com/openvswitch/ovs/archive/${OVS_VERSION}.tar.gz
to:
https://github.com/openvswitch/ovs.git branch-2.15

Signed-off-by: Salvatore Daniele <sdaniele@redhat.com>