### PR TITLE
Extract cookie information from OVN

### DIFF
--- a/containers/k8s-ofparse/Dockerfile.dev
+++ b/containers/k8s-ofparse/Dockerfile.dev
@@ -1,0 +1,64 @@
+FROM quay.io/fedora/fedora:33-x86_64 as builder
+
+ARG OVN_REPO=https://github.com/ovn-org/ovn.git
+ARG OVN_BRANCH=main
+ARG OVS_REPO=https://github.com/openvswitch/ovs.git
+ARG OVS_BRANCH=master
+
+RUN dnf upgrade -y && dnf install --best --refresh -y --setopt=tsflags=nodocs \
+	python3-pyyaml python3-pip bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
+        libpcap hostname kubernetes-client python3-openvswitch python3-pyOpenSSL  \
+        iptables iproute jq iputils strace socat\
+	@'Development Tools' rpm-build dnf-plugins-core kmod && \
+	dnf clean all && rm -rf /var/cache/dnf/*
+
+
+WORKDIR /root
+RUN git clone $OVS_REPO
+
+#Build OVS dependency
+WORKDIR /root/ovs
+RUN git fetch && git checkout $OVS_BRANCH && git log -n 1
+RUN sed -e 's/@VERSION@/0.0.1/' rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec
+RUN dnf builddep /tmp/ovs.spec -y
+RUN rm -f /tmp/ovs.spec
+
+#Build OVS binaries and install
+RUN echo "Building OVS rpm"
+RUN ./boot.sh
+RUN ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --enable-ssl
+RUN make rpm-fedora
+
+#Clone OVN Source Code
+WORKDIR /root
+RUN git clone $OVN_REPO
+
+#Build OVN binaries and install
+WORKDIR /root/ovn/
+RUN git fetch && git checkout $OVN_BRANCH && git log -n 1
+RUN ./boot.sh
+RUN ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-ovs-source=/root/ovs/
+RUN make rpm-fedora
+
+
+FROM quay.io/fedora/fedora:33-x86_64
+COPY --from=builder /root/ovn/rpm/rpmbuild/RPMS /root/ovn-rpmbuild
+COPY --from=builder /root/ovs/rpm/rpmbuild/RPMS /root/ovs-rpmbuild
+
+RUN dnf upgrade -y && dnf install --best --refresh -y --setopt=tsflags=nodocs \
+	python3-pyyaml python3-pip jq findutils grep git hostname kubernetes-client && \
+	dnf clean all && rm -rf /var/cache/dnf/*
+
+RUN find /root/ovs-rpmbuild -name "*.rpm" | grep -v src | xargs dnf install -y
+RUN find /root/ovn-rpmbuild -name "*.rpm" | grep -v src | xargs dnf install -y
+
+# Install ovs-dbg
+ADD . /root/ovs-dbg
+WORKDIR /root/ovs-dbg
+RUN python3 -m pip install .
+
+WORKDIR /root
+RUN rm -rf /root/ovs /root/ovn
+
+ADD containers/k8s-ofparse/monitor.sh /root/
+ENTRYPOINT ["/root/monitor.sh"]

--- a/containers/k8s-ofparse/monitor.sh
+++ b/containers/k8s-ofparse/monitor.sh
@@ -40,7 +40,7 @@ monitor() {
 #!/bin/bash
 
 OFPARSE_ARGS="$ofparse_args"
-exec ofparse \$OFPARSE_ARGS \$@
+exec ofparse \$OFPARSE_ARGS "\$@"
 EOF
     chmod +x /usr/local/bin/k8s-ofparse
 

--- a/docs/source/ofparse.rst
+++ b/docs/source/ofparse.rst
@@ -151,13 +151,16 @@ Openflow parsing
 
 The openflow flow parsing supports this extra formats:
 
-**Logic**: To print the logical representation of a flow run:
+Logic format
+************
+
+**logic**: To print the logical representation of a flow run:
 
 ::
 
     ofparse openflow logic
 
-(run `ofparse --help` for more details)
+(run `ofparse openflow logic --help` for more details)
 
 
 When printing a logical representation of a flow list, flows are grouped into *logical flows* that:
@@ -166,6 +169,50 @@ When printing a logical representation of a flow list, flows are grouped into *l
 - match on the same fields (regardless of the match value)
 - execute the same actions (regardless of the actions' arguments, except for resubmit and output)
 - Optionally, the *cookie* can be counted as part of the logical flow as well (*--cookie*)
+
+Flows are sorted by table and then by logical flow:
+
+
+::
+
+    TABLE 1
+     -> logial flow ( x n )
+       -> flow 1
+       -> flow 2
+       ...
+	
+
+Cookie format
+*************
+Use **cookie** format to sort the flows by cookie and then by table
+
+::
+
+    Cookie 0xa
+     -> TABLE 1
+       -> flow 1
+       -> flow 2
+       ...
+    -> TABLE 2
+    ...
+
+
+ovn-detrace integration
+***********************
+Both **cookie** and **logic** formats support integration with OVN, in particular with ovn-detrace
+utility.
+
+You will need a recent OVN version that contains a specific `ovn-detrace patch`_ as well as locally
+accesible OVN Northbound and OVN Southbound ovsdb-server instances running.
+
+If you have all that, you can enable ovn-detrace support and ofparse will use ovn-detrace to
+extract the OVN information for each cookie and print it alogside the Openflow flows.
+
+See help for more information:
+
+::
+
+    ofparse openflow cookie --help
 
 
 HTML representation
@@ -349,3 +396,4 @@ Note filtering is typically applied before the range is calculated.
 .. _ovs-actions: http://www.openvswitch.org/support/dist-docs/ovs-actions.7.html
 .. _ovs-fields: http://www.openvswitch.org/support/dist-docs/ovs-fields.7.html
 .. _ovs-ofctl: http://www.openvswitch.org/support/dist-docs/ovs-ofctl.8.txt
+.. _`ovn-detrace patch`: https://github.com/ovn-org/ovn/commit/d659b6538b00bd72aeca1fc5dd3a3c337ac53f37

--- a/k8s/k8s-ofparse.yaml
+++ b/k8s/k8s-ofparse.yaml
@@ -53,6 +53,10 @@ spec:
     env:
       - name: OVN_RUNDIR
         value: "/var/run/openvswitch"
+      - name: OVN_NB_DB
+        value: "unix:/var/run/openvswitch/ovnnb_db.sock"
+      - name: OVN_SB_DB
+        value: "unix:/var/run/openvswitch/ovnsb_db.sock"
       - name: OVS_RUNDIR
         value: "/var/run/openvswitch"
     command: ["/root/monitor.sh", "start"]

--- a/k8s/k8s-ofparse.yaml
+++ b/k8s/k8s-ofparse.yaml
@@ -45,7 +45,7 @@ spec:
         path: /var/run/openvswitch
   containers:
   - name: k8s-ofparse
-    image: quay.io/amorenoz/k8s-ofparse
+    image: quay.io/amorenoz/k8s-ofparse-devel
     #imagePullPolicy: Always
     volumeMounts:
       - mountPath: /var/run/openvswitch/
@@ -80,7 +80,7 @@ spec:
             path: /var/run/openvswitch
       containers:
       - name: k8s-ofparse
-        image: quay.io/amorenoz/k8s-ofparse
+        image: quay.io/amorenoz/k8s-ofparse-devel
         #imagePullPolicy: Always
         volumeMounts:
           - mountPath: /var/run/openvswitch/

--- a/ovs_dbg/odp.py
+++ b/ovs_dbg/odp.py
@@ -196,7 +196,7 @@ class ODPFlowFactory:
                         ),
                         "userdata": decode_default,
                         "actions": decode_flag,
-                        "tunnel_out_port": decode_int,
+                        "tunnel_out_port": decode_default,
                         "push_eth": nested_kv_decoder(
                             KVDecoders(
                                 {

--- a/ovs_dbg/ofparse/ofp.py
+++ b/ovs_dbg/ofparse/ofp.py
@@ -1,7 +1,7 @@
 import click
 
 from ovs_dbg.ofp import OFPFlowFactory
-from ovs_dbg.ofparse.ofp_logic import LogicFlowProcessor
+from ovs_dbg.ofparse.ofp_logic import LogicFlowProcessor, CookieProcessor
 from ovs_dbg.ofparse.main import maincli
 from ovs_dbg.ofparse.process import (
     FlowProcessor,
@@ -9,7 +9,6 @@ from ovs_dbg.ofparse.process import (
     ConsoleProcessor,
 )
 from ovs_dbg.ofparse.html import HTMLBuffer, HTMLFormatter, HTMLStyle
-
 
 factory = OFPFlowFactory()
 
@@ -159,3 +158,12 @@ def html(opts):
     processor = HTMLProcessor(opts, factory)
     processor.process()
     print(processor.html())
+
+
+@openflow.command()
+@click.pass_obj
+def cookie(opts):
+    """Print the flow tables sorted by cookie"""
+    processor = CookieProcessor(opts, factory)
+    processor.process()
+    processor.print()

--- a/ovs_dbg/ofparse/ofp.py
+++ b/ovs_dbg/ofparse/ofp.py
@@ -205,8 +205,18 @@ def ovn_detrace_callback(ctx, param, value):
     "Otherwise, the default is unix:/var/run/ovn/ovnnb_db.sock",
     callback=ovn_detrace_callback,
 )
+@click.option(
+    "-o",
+    "--ovn-filter",
+    help="Specify a filter to be run on ovn-detrace information (implied -d). "
+    "Format: python regular expression "
+    "(see https://docs.python.org/3/library/re.html)",
+    callback=ovn_detrace_callback,
+)
 @click.pass_obj
-def cookie(opts, ovn_detrace_flag, ovn_detrace_path, ovnnb_db, ovnsb_db):
+def cookie(
+    opts, ovn_detrace_flag, ovn_detrace_path, ovnnb_db, ovnsb_db, ovn_filter
+):
     """Print the flow tables sorted by cookie"""
     if ovn_detrace_flag:
         opts["ovn_detrace_flag"] = True

--- a/ovs_dbg/ofparse/ofp_logic.py
+++ b/ovs_dbg/ofparse/ofp_logic.py
@@ -1,5 +1,6 @@
 import sys
 import io
+import re
 
 from rich.tree import Tree
 from rich.text import Text
@@ -295,12 +296,20 @@ class CookieProcessor(FlowProcessor):
                 tree = Tree("Ofproto Cookie Tree")
 
                 for cookie, tables in cookies.items():
+                    ovn_info = None
+                    if self.ovn_detrace:
+                        ovn_info = self.ovn_detrace.get_ovn_info(cookie)
+                        if self.opts.get("ovn_filter"):
+                            ovn_regexp = re.compile(
+                                self.opts.get("ovn_filter")
+                            )
+                            if not ovn_regexp.search(ovn_info):
+                                continue
+
                     cookie_tree = tree.add(
                         "** Cookie {} **".format(hex(cookie))
                     )
-
-                    if self.ovn_detrace:
-                        ovn_info = self.ovn_detrace.get_ovn_info(cookie)
+                    if ovn_info:
                         ovn = cookie_tree.add("OVN Info")
                         for part in ovn_info.split("\n"):
                             if part.strip():


### PR DESCRIPTION
Recent OVN versions make it a bit easier to [use ovn-detrace externally](https://github.com/ovn-org/ovn/commit/d659b6538b00bd72aeca1fc5dd3a3c337ac53f37). This enables us to use ovn-detrace to query OVN about the information it has on each cookie.

This PR adds a new cookie format for openflow flows which sorts flows first by cookie and then by table. Then, uses ovn-detrace to append OVN information about each cookie.