### PR TITLE
ovs-offline: fix DPDK netdevs not appearing in ofproto bridge

### DIFF
--- a/containers/ovs-dbg/Dockerfile
+++ b/containers/ovs-dbg/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build /usr/local/etc/openvswitch /usr/local/etc/openvswitch
 COPY --from=build /usr/local/share/openvswitch /usr/local/share/openvswitch
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
 
-RUN dnf install -y libatomic openssl gdb
+RUN dnf install -y libatomic openssl gdb jq
 
 RUN mkdir -p /usr/local/var/run/openvswitch
 

--- a/containers/ovs-dbg/start.sh
+++ b/containers/ovs-dbg/start.sh
@@ -28,6 +28,13 @@ vswitchd-dummy() {
     user_opt="--user ${container_user}"
   fi
 
+  # Replace DPDK netdevs with dummy ones
+  for netdev in dpdk dpdkvhostuser dpdkvhostuserclient; do
+    for iface in $(ovs-vsctl --format json --columns=_uuid find Interface type=${netdev} | jq -r '.data[][0][1]'); do
+        ovs-vsctl --no-wait set Interface $iface type=dummy;
+    done
+  done
+
   ovs-vswitchd ${user_opt-} --enable-dummy=override -vvconn -vnetdev_dummy  --no-chdir --pidfile  -vsyslog:off unix:${OVSDB_SOCKET}
 
 }


### PR DESCRIPTION
DPDK netdevs are not registered if DPDK is not initialized so creating
them fails even if we are latter going to override them with the dummy
implementation.

To make them work, just replace them manually on the DB before startup.

Fixes: #101 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>