### PR TITLE
Fix vendor library inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Latest released version:
 
 From the git checkout
 
-    pip install .
+    ./prepare.sh && pip install .
 
 ## Enable bash autocomplete
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     keywords="ovs_dbg",
     name="ovs_dbg",
     packages=find_namespace_packages(
-        include=["ovs_dbg", "ovs_dbg.ofparse", "ovs_dbg.vendor.ovs.flow"]
+        include=["ovs_dbg", "ovs_dbg.ofparse", "ovs_dbg.vendor.ovs"]
     ),
     setup_requires=setup_requirements,
     scripts=[


### PR DESCRIPTION
It might conflict with the installed library and without the __init__.py files it seems the include system is not giving it precedence. 

Fixes #110 