### PR TITLE
Updates CI to 22.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7']
+        python-version: ['3.7', '3.9', '3.11']
     name: Python ${{ matrix.python-version }} build
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and Publish to PyPI or TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and Publish to PyPI or TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Upgrade pip
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
As runners move from 20.04 to 22.04, the matrix moves to cover more latest versions and dropping 3.6.