### PR TITLE
Added OVN-IC path for collect-sos-ovn subcommand, so it works for OCP 4.14+

### DIFF
--- a/bin/ovs-offline
+++ b/bin/ovs-offline
@@ -214,7 +214,7 @@ do_collect-sos-ovn() {
         exit 1
     fi
     local sos=$1
-    local db_locations="var/lib/openvswitch/ovn usr/local/etc/openvswitch etc/openvswitch var/lib/openvswitch var/lib/ovn/etc"
+    local db_locations="var/lib/openvswitch/ovn usr/local/etc/openvswitch etc/openvswitch var/lib/openvswitch var/lib/ovn/etc var/lib/ovn-ic/etc"
 
     mkdir -p ${SOS_DIR}
 


### PR DESCRIPTION
With the new OVN-Kubernetes interconnection scheme added in 4.14, all the nodes now have their own OVN databases and those are located in folders different from the previous location.

The sos report module `openshift_ovn` usually gathers them, but places them in the current location, so `ovs-offline` cannot find them.

This PR just adds the new path to the locations to search at while collecting OVN information from sosreport.